### PR TITLE
Fix plt.plot() fmt keyword argument in plot_history

### DIFF
--- a/keeks/bankroll.py
+++ b/keeks/bankroll.py
@@ -183,7 +183,7 @@ class BankRoll:
             If provided, saves the plot to the specified filename instead of displaying it.
         """
         plt.figure()
-        plt.plot(list(range(len(self.history))), self.history, fmt="bo-")
+        plt.plot(list(range(len(self.history))), self.history, "bo-")
         if fname:
             plt.savefig(fname)
         else:


### PR DESCRIPTION
## Summary
- Fixed `plot_history()` method in `BankRoll` class that was passing `fmt="bo-"` as a keyword argument to `plt.plot()`
- `matplotlib.pyplot.plot()` expects the format string as a positional argument, not a keyword argument
- This was causing `AttributeError: Line2D.set() got an unexpected keyword argument 'fmt'`

## Test plan
- [x] Ran `keeks_example.py` with the fix - plot displays correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)